### PR TITLE
Store a balloon's static properties when placed in a cloud chest, fix ghost items when replacing balloons

### DIFF
--- a/src/main/java/com/github/alexthe668/cloudstorage/block/AbstractCloudChestBlockEntity.java
+++ b/src/main/java/com/github/alexthe668/cloudstorage/block/AbstractCloudChestBlockEntity.java
@@ -137,7 +137,11 @@ public abstract class AbstractCloudChestBlockEntity extends BlockEntity {
 
     public abstract int getBalloonFor(Player player);
 
+    public abstract boolean getBalloonStaticFor(Player player);
+
     public abstract void setBalloonColorFor(Player player, int color);
+
+    public abstract void setBalloonStaticFor(Player player, boolean isStatic);
 
     private ItemStack getValidBalloonStack(Player player) {
         ItemStack itemStack1 = player.getMainHandItem();

--- a/src/main/java/com/github/alexthe668/cloudstorage/block/StaticCloudChestBlockEntity.java
+++ b/src/main/java/com/github/alexthe668/cloudstorage/block/StaticCloudChestBlockEntity.java
@@ -30,6 +30,7 @@ public class StaticCloudChestBlockEntity extends AbstractCloudChestBlockEntity {
 
     private static final Component CONTAINER_TITLE = new TranslatableComponent("cloudstorage.container.static_cloud_chest");
     private int balloonColor = -1;
+    private boolean balloonStatic = false;
     private net.minecraftforge.common.util.LazyOptional<? extends net.minecraftforge.items.IItemHandler> input = LazyOptional.empty();
 
     public StaticCloudChestBlockEntity(BlockPos pos, BlockState state) {
@@ -47,8 +48,17 @@ public class StaticCloudChestBlockEntity extends AbstractCloudChestBlockEntity {
     }
 
     @Override
+    public boolean getBalloonStaticFor(Player player) { return balloonStatic; }
+
+    @Override
     public void setBalloonColorFor(Player player, int color) {
         balloonColor = color;
+        this.setChanged();
+    }
+
+    @Override
+    public void setBalloonStaticFor(Player player, boolean isStatic) {
+        balloonStatic = isStatic;
         this.setChanged();
     }
 
@@ -84,11 +94,13 @@ public class StaticCloudChestBlockEntity extends AbstractCloudChestBlockEntity {
     public void load(CompoundTag tag) {
         super.load(tag);
         balloonColor = tag.getInt("BalloonColor");
+        balloonStatic = tag.getBoolean("BalloonStatic");
     }
 
     protected void saveAdditional(CompoundTag tag) {
         super.saveAdditional(tag);
         tag.putInt("BalloonColor", balloonColor);
+        tag.putBoolean("BalloonStatic", balloonStatic);
     }
 
     @Override
@@ -124,6 +136,7 @@ public class StaticCloudChestBlockEntity extends AbstractCloudChestBlockEntity {
             Vec3 releasePosition = Vec3.atBottomCenterOf(this.getBlockPos()).add(0, getEmergence(1.0F) * 2F, 0);
             BalloonEntity balloon = CSEntityRegistry.BALLOON.get().create(level);
             balloon.setBalloonColor(this.balloonColor);
+            balloon.setCharged(this.balloonStatic);
             balloon.setStringLength(BalloonEntity.DEFAULT_STRING_LENGTH);
             balloon.setPos(releasePosition);
             level.addFreshEntity(balloon);

--- a/src/main/java/com/github/alexthe668/cloudstorage/item/BalloonItem.java
+++ b/src/main/java/com/github/alexthe668/cloudstorage/item/BalloonItem.java
@@ -206,7 +206,7 @@ public class BalloonItem extends Item implements DyeableLeatherItem {
             }
             level.setBlockAndUpdate(blockpos, CSBlockRegistry.STATIC_CLOUD.get().defaultBlockState());
             return true;
-        } else if (player != null && (blockstate.is(CSBlockRegistry.CLOUD_CHEST.get()) || blockstate.is(CSBlockRegistry.STATIC_CLOUD_CHEST.get()))) {
+        } else if (player != null && ((!isStatic(itemstack) && blockstate.is(CSBlockRegistry.CLOUD_CHEST.get())) || (isStatic(itemstack) && blockstate.is(CSBlockRegistry.STATIC_CLOUD_CHEST.get())))) {
             BlockEntity te = level.getBlockEntity(blockpos);
             if (te instanceof AbstractCloudChestBlockEntity cloudChest) {
                 if (cloudChest.hasBalloonFor(player)) {

--- a/src/main/java/com/github/alexthe668/cloudstorage/item/BalloonItem.java
+++ b/src/main/java/com/github/alexthe668/cloudstorage/item/BalloonItem.java
@@ -105,12 +105,10 @@ public class BalloonItem extends Item implements DyeableLeatherItem {
         }
     }
 
-    public ItemStack createBalloon(int color, boolean lgihtning) {
-        CompoundTag tag = new CompoundTag();
-        tag.putBoolean("static", lgihtning);
-        tag.putInt("color", color);
+    public ItemStack createBalloon(int color, boolean lightning) {
         ItemStack stack = new ItemStack(this);
-        stack.setTag(tag);
+        this.setColor(stack, color);
+        this.setStatic(stack, lightning);
         return stack;
     }
 
@@ -120,8 +118,14 @@ public class BalloonItem extends Item implements DyeableLeatherItem {
 
     @Override
     public void setColor(ItemStack stack, int colorHex) {
-        if(colorHex != DEFAULT_COLOR){
+        if (colorHex != DEFAULT_COLOR) {
             stack.getOrCreateTagElement("display").putInt("color", colorHex);
+        }
+    }
+
+    public void setStatic(ItemStack stack, boolean isStatic) {
+        if (isStatic) {
+            stack.getOrCreateTag().putBoolean("static", true);
         }
     }
 
@@ -206,12 +210,17 @@ public class BalloonItem extends Item implements DyeableLeatherItem {
             BlockEntity te = level.getBlockEntity(blockpos);
             if (te instanceof AbstractCloudChestBlockEntity cloudChest) {
                 if (cloudChest.hasBalloonFor(player)) {
-                    this.setColor(itemstack, cloudChest.getBalloonFor(player));
-                    ItemEntity itemEntity = new ItemEntity(level, blockpos.getX() + 0.5F, blockpos.getY() + 0.75F, blockpos.getZ() + 0.5F, itemstack);
+                    ItemStack newBalloon = new ItemStack(CSItemRegistry.BALLOON.get());
+                    newBalloon.setCount(1);
+                    BalloonItem newBalloonItem = (BalloonItem) newBalloon.getItem();
+                    newBalloonItem.setColor(newBalloon, cloudChest.getBalloonFor(player));
+                    newBalloonItem.setStatic(newBalloon, cloudChest.getBalloonStaticFor(player));
+                    ItemEntity itemEntity = new ItemEntity(level, blockpos.getX() + 0.5F, blockpos.getY() + 0.75F, blockpos.getZ() + 0.5F, newBalloon);
                     itemEntity.setDefaultPickUpDelay();
                     level.addFreshEntity(itemEntity);
                 }
                 cloudChest.setBalloonColorFor(player, this.getColor(itemstack));
+                cloudChest.setBalloonStaticFor(player, isStatic(itemstack));
                 itemstack.shrink(1);
                 return true;
             }


### PR DESCRIPTION
Store a balloon's static properties when placed in a cloud chest (fixes #6) and fixes ghost items and missing items when balloons are replaced in a cloud chest (fixes #5).