### PR TITLE
Convert cloud blocks to static cloud blocks when struck by lightning

### DIFF
--- a/src/main/java/com/github/alexthe668/cloudstorage/mixin/LightningBoltMixin.java
+++ b/src/main/java/com/github/alexthe668/cloudstorage/mixin/LightningBoltMixin.java
@@ -1,0 +1,76 @@
+package com.github.alexthe668.cloudstorage.mixin;
+
+import com.github.alexthe668.cloudstorage.block.CSBlockRegistry;
+import com.github.alexthe668.cloudstorage.block.CloudBlock;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.LightningRodBlock;
+import net.minecraft.world.level.block.WeatheringCopper;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import net.minecraft.world.entity.LightningBolt;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Optional;
+
+@Mixin(LightningBolt.class)
+public abstract class LightningBoltMixin {
+
+    @Inject(
+            method = {"clearCopperOnLightningStrike"},
+            at = @At("TAIL")
+    )
+    private static void chargeCloudBlocks(Level level, BlockPos pos, CallbackInfo ci) {
+        BlockState blockstate = level.getBlockState(pos);
+        BlockPos blockpos;
+        BlockState blockstate1;
+        if (blockstate.is(Blocks.LIGHTNING_ROD)) {
+            blockpos = pos.relative(blockstate.getValue(LightningRodBlock.FACING).getOpposite());
+            blockstate1 = level.getBlockState(blockpos);
+        } else {
+            blockpos = pos;
+            blockstate1 = blockstate;
+        }
+
+        if (blockstate1.getBlock() instanceof CloudBlock) {
+            level.setBlockAndUpdate(blockpos, CSBlockRegistry.STATIC_CLOUD.get().defaultBlockState());
+            BlockPos.MutableBlockPos blockpos$mutableblockpos = pos.mutable();
+            int i = level.random.nextInt(3) + 3;
+
+            for(int j = 0; j < i; ++j) {
+                int k = level.random.nextInt(8) + 1;
+                chargeRandomCloudsNearby(level, blockpos, blockpos$mutableblockpos, k);
+            }
+
+        }
+    }
+
+    private static void chargeRandomCloudsNearby(Level level, BlockPos blockpos, BlockPos.MutableBlockPos blockpos$mutableblockpos, int k) {
+        blockpos$mutableblockpos.set(blockpos);
+
+        for(int i = 0; i < k; ++i) {
+            Optional<BlockPos> optional = chargeRandomCloud(level, blockpos$mutableblockpos);
+            if (!optional.isPresent()) {
+                break;
+            }
+
+            blockpos$mutableblockpos.set(optional.get());
+        }
+    }
+
+    private static Optional<BlockPos> chargeRandomCloud(Level level, BlockPos blockpos2) {
+        for(BlockPos blockpos : BlockPos.randomInCube(level.random, 10, blockpos2, 1)) {
+            BlockState blockstate = level.getBlockState(blockpos);
+            if (blockstate.getBlock() instanceof CloudBlock) {
+                level.setBlockAndUpdate(blockpos, CSBlockRegistry.STATIC_CLOUD.get().defaultBlockState());
+                level.levelEvent(3002, blockpos, -1);
+                return Optional.of(blockpos);
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/resources/cloudstorage.mixins.json
+++ b/src/main/resources/cloudstorage.mixins.json
@@ -6,6 +6,7 @@
   "refmap": "cloudstorage.refmap.json",
   "mixins": [
     "CelebrateVillagersSurvivedRaidMixin",
+    "LightningBoltMixin",
     "PoolsMixin"
   ],
   "client": [


### PR DESCRIPTION
Converts cloud blocks that are struck by lightning into static cloud blocks.

Code is basically copied from vanilla for copper, and there wasn't really a better way to do this via a mixin without duplicating all the code.